### PR TITLE
Prevent unsaved changes prompt on successful submit

### DIFF
--- a/resources/views/agri-tips/edit.blade.php
+++ b/resources/views/agri-tips/edit.blade.php
@@ -164,6 +164,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const submitBtn = document.getElementById('submitBtn');
     const titleCounter = document.getElementById('titleCounter');
     const descriptionCounter = document.getElementById('descriptionCounter');
+    let isSubmitting = false;
 
     // Store original values to detect changes
     const originalValues = {
@@ -306,6 +307,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
             }, 5000);
         } else {
+            // Mark as submitting to skip the beforeunload prompt on successful submit
+            isSubmitting = true;
             // Disable submit button to prevent double submission
             submitBtn.disabled = true;
             submitBtn.innerHTML = `
@@ -320,6 +323,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Warn user about unsaved changes when leaving page
     window.addEventListener('beforeunload', function(e) {
+        if (isSubmitting) {
+            return; // allow navigation without prompt during submit/redirect
+        }
         if (hasChanges()) {
             e.preventDefault();
             e.returnValue = 'আপনার পরিবর্তনগুলো সংরক্ষিত হয়নি। আপনি কি নিশ্চিত যে আপনি পেজ ছেড়ে যেতে চান?';


### PR DESCRIPTION
Introduces an isSubmitting flag to bypass the beforeunload warning when the form is being submitted, allowing smooth navigation after a successful submission and preventing unnecessary prompts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading state on the Agri Tips edit form: submit button shows a spinner with “আপডেট করা হচ্ছে...” and is disabled during submission.

* **Bug Fixes**
  * Prevents the unsaved changes prompt from appearing while a valid submission is in progress.
  * Reduces risk of duplicate submissions by disabling the submit button during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->